### PR TITLE
Refaz o Controller de Usuarios utilizando Prisma ORM

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /node_modules
 .env
+.idea/

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,8 +16,11 @@
         "jsonwebtoken": "^9.0.2",
         "mysql2": "^3.10.3",
         "nodemailer": "^6.9.14",
-        "nodemon": "^3.1.4",
-        "prisma": "^5.17.0"
+        "nodemon": "^3.1.4"
+      },
+      "devDependencies": {
+        "@prisma/client": "^5.18.0",
+        "prisma": "^5.18.0"
       }
     },
     "node_modules/@mapbox/node-pre-gyp": {
@@ -39,44 +42,67 @@
         "node-pre-gyp": "bin/node-pre-gyp"
       }
     },
+    "node_modules/@prisma/client": {
+      "version": "5.18.0",
+      "resolved": "https://registry.npmjs.org/@prisma/client/-/client-5.18.0.tgz",
+      "integrity": "sha512-BWivkLh+af1kqC89zCJYkHsRcyWsM8/JHpsDMM76DjP3ZdEquJhXa4IeX+HkWPnwJ5FanxEJFZZDTWiDs/Kvyw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "engines": {
+        "node": ">=16.13"
+      },
+      "peerDependencies": {
+        "prisma": "*"
+      },
+      "peerDependenciesMeta": {
+        "prisma": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@prisma/debug": {
-      "version": "5.17.0",
-      "resolved": "https://registry.npmjs.org/@prisma/debug/-/debug-5.17.0.tgz",
-      "integrity": "sha512-l7+AteR3P8FXiYyo496zkuoiJ5r9jLQEdUuxIxNCN1ud8rdbH3GTxm+f+dCyaSv9l9WY+29L9czaVRXz9mULfg=="
+      "version": "5.18.0",
+      "resolved": "https://registry.npmjs.org/@prisma/debug/-/debug-5.18.0.tgz",
+      "integrity": "sha512-f+ZvpTLidSo3LMJxQPVgAxdAjzv5OpzAo/eF8qZqbwvgi2F5cTOI9XCpdRzJYA0iGfajjwjOKKrVq64vkxEfUw==",
+      "dev": true
     },
     "node_modules/@prisma/engines": {
-      "version": "5.17.0",
-      "resolved": "https://registry.npmjs.org/@prisma/engines/-/engines-5.17.0.tgz",
-      "integrity": "sha512-+r+Nf+JP210Jur+/X8SIPLtz+uW9YA4QO5IXA+KcSOBe/shT47bCcRMTYCbOESw3FFYFTwe7vU6KTWHKPiwvtg==",
+      "version": "5.18.0",
+      "resolved": "https://registry.npmjs.org/@prisma/engines/-/engines-5.18.0.tgz",
+      "integrity": "sha512-ofmpGLeJ2q2P0wa/XaEgTnX/IsLnvSp/gZts0zjgLNdBhfuj2lowOOPmDcfKljLQUXMvAek3lw5T01kHmCG8rg==",
+      "dev": true,
       "hasInstallScript": true,
       "dependencies": {
-        "@prisma/debug": "5.17.0",
-        "@prisma/engines-version": "5.17.0-31.393aa359c9ad4a4bb28630fb5613f9c281cde053",
-        "@prisma/fetch-engine": "5.17.0",
-        "@prisma/get-platform": "5.17.0"
+        "@prisma/debug": "5.18.0",
+        "@prisma/engines-version": "5.18.0-25.4c784e32044a8a016d99474bd02a3b6123742169",
+        "@prisma/fetch-engine": "5.18.0",
+        "@prisma/get-platform": "5.18.0"
       }
     },
     "node_modules/@prisma/engines-version": {
-      "version": "5.17.0-31.393aa359c9ad4a4bb28630fb5613f9c281cde053",
-      "resolved": "https://registry.npmjs.org/@prisma/engines-version/-/engines-version-5.17.0-31.393aa359c9ad4a4bb28630fb5613f9c281cde053.tgz",
-      "integrity": "sha512-tUuxZZysZDcrk5oaNOdrBnnkoTtmNQPkzINFDjz7eG6vcs9AVDmA/F6K5Plsb2aQc/l5M2EnFqn3htng9FA4hg=="
+      "version": "5.18.0-25.4c784e32044a8a016d99474bd02a3b6123742169",
+      "resolved": "https://registry.npmjs.org/@prisma/engines-version/-/engines-version-5.18.0-25.4c784e32044a8a016d99474bd02a3b6123742169.tgz",
+      "integrity": "sha512-a/+LpJj8vYU3nmtkg+N3X51ddbt35yYrRe8wqHTJtYQt7l1f8kjIBcCs6sHJvodW/EK5XGvboOiwm47fmNrbgg==",
+      "dev": true
     },
     "node_modules/@prisma/fetch-engine": {
-      "version": "5.17.0",
-      "resolved": "https://registry.npmjs.org/@prisma/fetch-engine/-/fetch-engine-5.17.0.tgz",
-      "integrity": "sha512-ESxiOaHuC488ilLPnrv/tM2KrPhQB5TRris/IeIV4ZvUuKeaicCl4Xj/JCQeG9IlxqOgf1cCg5h5vAzlewN91Q==",
+      "version": "5.18.0",
+      "resolved": "https://registry.npmjs.org/@prisma/fetch-engine/-/fetch-engine-5.18.0.tgz",
+      "integrity": "sha512-I/3u0x2n31rGaAuBRx2YK4eB7R/1zCuayo2DGwSpGyrJWsZesrV7QVw7ND0/Suxeo/vLkJ5OwuBqHoCxvTHpOg==",
+      "dev": true,
       "dependencies": {
-        "@prisma/debug": "5.17.0",
-        "@prisma/engines-version": "5.17.0-31.393aa359c9ad4a4bb28630fb5613f9c281cde053",
-        "@prisma/get-platform": "5.17.0"
+        "@prisma/debug": "5.18.0",
+        "@prisma/engines-version": "5.18.0-25.4c784e32044a8a016d99474bd02a3b6123742169",
+        "@prisma/get-platform": "5.18.0"
       }
     },
     "node_modules/@prisma/get-platform": {
-      "version": "5.17.0",
-      "resolved": "https://registry.npmjs.org/@prisma/get-platform/-/get-platform-5.17.0.tgz",
-      "integrity": "sha512-UlDgbRozCP1rfJ5Tlkf3Cnftb6srGrEQ4Nm3og+1Se2gWmCZ0hmPIi+tQikGDUVLlvOWx3Gyi9LzgRP+HTXV9w==",
+      "version": "5.18.0",
+      "resolved": "https://registry.npmjs.org/@prisma/get-platform/-/get-platform-5.18.0.tgz",
+      "integrity": "sha512-Tk+m7+uhqcKDgnMnFN0lRiH7Ewea0OEsZZs9pqXa7i3+7svS3FSCqDBCaM9x5fmhhkufiG0BtunJVDka+46DlA==",
+      "dev": true,
       "dependencies": {
-        "@prisma/debug": "5.17.0"
+        "@prisma/debug": "5.18.0"
       }
     },
     "node_modules/abbrev": {
@@ -1388,12 +1414,13 @@
       }
     },
     "node_modules/prisma": {
-      "version": "5.17.0",
-      "resolved": "https://registry.npmjs.org/prisma/-/prisma-5.17.0.tgz",
-      "integrity": "sha512-m4UWkN5lBE6yevqeOxEvmepnL5cNPEjzMw2IqDB59AcEV6w7D8vGljDLd1gPFH+W6gUxw9x7/RmN5dCS/WTPxA==",
+      "version": "5.18.0",
+      "resolved": "https://registry.npmjs.org/prisma/-/prisma-5.18.0.tgz",
+      "integrity": "sha512-+TrSIxZsh64OPOmaSgVPH7ALL9dfU0jceYaMJXsNrTkFHO7/3RANi5K2ZiPB1De9+KDxCWn7jvRq8y8pvk+o9g==",
+      "dev": true,
       "hasInstallScript": true,
       "dependencies": {
-        "@prisma/engines": "5.17.0"
+        "@prisma/engines": "5.18.0"
       },
       "bin": {
         "prisma": "build/index.js"

--- a/package.json
+++ b/package.json
@@ -17,7 +17,10 @@
     "jsonwebtoken": "^9.0.2",
     "mysql2": "^3.10.3",
     "nodemailer": "^6.9.14",
-    "nodemon": "^3.1.4",
-    "prisma": "^5.17.0"
+    "nodemon": "^3.1.4"
+  },
+  "devDependencies": {
+    "@prisma/client": "^5.18.0",
+    "prisma": "^5.18.0"
   }
 }

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1,0 +1,68 @@
+generator client {
+  provider = "prisma-client-js"
+}
+
+datasource db {
+  provider          = "mysql"
+  url               = env("DATABASE_URL")
+  shadowDatabaseUrl = env("SHADOW_DATABASE_URL")
+}
+
+model avaliacoes {
+  avaliacao_id      Int      @id @default(autoincrement())
+  avaliacao_opiniao String   @db.VarChar(255)
+  avaliacao_nota    Int      @default(5)
+  avaliacao_data    DateTime @default(now()) @db.DateTime(0)
+  usuario_id        Int
+}
+
+model enderecos {
+  endereco_estado      String  @db.VarChar(25)
+  endereco_cidade      String  @db.VarChar(50)
+  endereco_bairro      String  @db.VarChar(25)
+  endereco_rua         String  @db.VarChar(50)
+  endereco_numero      String  @db.VarChar(5)
+  endereco_complemento String? @db.VarChar(100)
+  endereco_referencia  String? @db.VarChar(100)
+  endereco_cep         String  @db.VarChar(10)
+  endereco_id          Int     @id @default(autoincrement())
+}
+
+model produtos {
+  produto_id          Int       @id @default(autoincrement())
+  produto_nome        String    @db.VarChar(255)
+  produto_descricao   String    @db.Text
+  produto_preco       Int
+  produto_status      Boolean   @default(true)
+  produto_estoque     Int
+  categoria_id        Int
+  marca_id            Int
+  produto_peso        Int?
+  produto_altura      Int?
+  produto_comprimento Int?
+  produto_imagem      Int?
+  produto_em_promocao Boolean   @default(false)
+  produto_destaque    Boolean   @default(false)
+  produto_tags        Int?
+  criado_em           DateTime  @default(now()) @db.DateTime(0)
+  atualizado_em       DateTime? @default(now()) @db.DateTime(0)
+  produto_largura     Int?
+}
+
+model tarefas {
+  tarefa_id        Int    @id @default(autoincrement())
+  tarefa_titulo    String @db.VarChar(50)
+  tarefa_descricao String @db.VarChar(255)
+  categoria_id     Int?
+}
+
+model usuarios {
+  usuario_id         Int      @id @default(autoincrement())
+  usuario_email      String   @unique(map: "usuario_email") @db.VarChar(200)
+  usuario_senha      String?  @db.VarChar(255)
+  usuario_nome       String   @db.VarChar(100)
+  usuario_cpf        String   @db.VarChar(20)
+  usuario_celular    String?  @db.VarChar(20)
+  usuario_newsletter Boolean? @default(false)
+  created_at         DateTime @default(now()) @db.DateTime(0)
+}

--- a/src/controllers/usuarioController.js
+++ b/src/controllers/usuarioController.js
@@ -1,55 +1,37 @@
-const { executarSQL } = require('../database/index')
+const { executarSQL, prisma } = require('../database/index')
 const jwt = require('jsonwebtoken')
 const bcrypt = require('bcrypt')
+const {PrismaClient} = require("@prisma/client")
 require('dotenv').config()
 
-async function listarUsuarios(){
-    return await executarSQL("SELECT * FROM usuarios;")
+async function listarUsuarios(req,res){
+    return prisma.usuarios.findMany()
 }
 
 async function listarUmUsuario(id){
-    const response = await executarSQL(`SELECT * FROM usuarios WHERE usuario_id = ${id}`)
-    try {
-        if (0 < response.length){
-            return response[0]
-        }else{
-            return {
-                status: 404,
-                detail: "Usuario não encontrado.",
-                severity: "warn"
-            }
+    return prisma.usuarios.findFirst({
+        where: {
+            usuario_id: id
         }
-    } catch (error) {
-        return {
-            status: 422,
-            detail: error.message,
-            severity: "danger"
-        }
-    }
+    })
 }
 
 async function cadastrarUsuario(data){
-
     const saltRounds = 10;
     const senhaEncriptada = await bcrypt.hash(data.usuario_senha, saltRounds)
     try {
-        const response = await executarSQL(`INSERT INTO usuarios (
-            usuario_email,
-            usuario_senha,
-            usuario_nome,
-            usuario_cpf,
-            usuario_celular,
-            usuario_newsletter
-            ) VALUES (
-            '${data.usuario_email}',
-            '${senhaEncriptada}',
-            '${data.usuario_nome}',
-            '${data.usuario_cpf}',
-            '${data.usuario_celular}',
-            '${data.usuario_newsletter}'
-        );`)
-        
-        if(0 < response.affectedRows){
+        const novoUsuario = await prisma.usuarios.create({
+            data: {
+                usuario_email: data.usuario_email,
+                usuario_senha: senhaEncriptada,
+                usuario_nome: data.usuario_nome,
+                usuario_cpf: data.usuario_cpf,
+                usuario_celular: data.usuario_celular,
+                usuario_newsletter: data.usuario_newsletter
+            }
+        });
+
+        if(novoUsuario){
             return {
                 status: 200,
                 detail: "Usuario cadastrado com sucesso.",
@@ -69,27 +51,22 @@ async function cadastrarUsuario(data){
             severity: "danger"
         }
     }
-
 }
 
 async function apagarUsuario(id){
-    
     try {
-        const response = await executarSQL(`DELETE FROM usuarios WHERE usuario_id = ${id}`)
-        if(0 < response.affectedRows){
+        const usuarioApagado = await prisma.usuarios.delete({
+            where: {
+                usuario_id: parseInt(id)
+            }
+        })
+        if(usuarioApagado){
             return {
                 status: 200,
                 detail: "Usuario apagado.",
                 severity: "success"
             }
-        }else{
-            return {
-                status: 422,
-                detail: "Usuario não encontrado.",
-                severity: "success"
-            }
         }
-        
     } catch (error) {
         return {
             status: 422,
@@ -105,31 +82,25 @@ async function editarUsuario(data){
     const senhaEncriptada = await bcrypt.hash(data.usuario_senha, saltRounds)
 
     try {
-        const response = await executarSQL(`UPDATE usuarios SET
-        usuario_email = "${data.usuario_email}",
-        usuario_senha = "${senhaEncriptada}",
-        usuario_nome = "${data.usuario_nome}",
-        usuario_cpf = "${data.usuario_cpf}",
-        usuario_celular = "${data.usuario_celular}",
-        usuario_newsletter = "${data.usuario_newsletter}"
-        WHERE
-        usuario_id = ${data.usuario_id}
-        ;`)
-
-        if(0 < response.affectedRows){
+        const usuarioAtualizado = await prisma.usuarios.update({
+            where: {
+                usuario_id: data.usuario_id
+            },
+            data: {
+                usuario_email: data.usuario_email,
+                usuario_nome: data.usuario_nome,
+                usuario_cpf: data.usuario_cpf,
+                usuario_celular: data.usuario_celular,
+                usuario_newsletter: data.usuario_newsletter
+            }
+        })
+        if(usuarioAtualizado){
             return {
                 status: 200,
                 detail: "Usuario atualizado.",
                 severity: "success"
             }
-        }else{
-            return {
-                status: 422,
-                detail: "Usuario não encontrado.",
-                severity: "warn"
-            }
         }
-        
     } catch (error) {
         return {
             status: 422,
@@ -149,23 +120,23 @@ async function logar(data){
             throw new Error("Campo senha é obrigatório!")
         }
 
-        const response = await executarSQL(`SELECT * FROM usuarios WHERE usuario_email = '${data.usuario_email}';`)
-
-        if(0 < response.length){
-            const usuario = response[0]
-            const aSenhaEstaCorreta = await bcrypt.compare(data.usuario_senha, usuario.usuario_senha)
+        const usuarioLogando = await prisma.usuarios.findFirst({
+            where: {
+                usuario_email: data.usuario_email
+            }
+        })
+        if(usuarioLogando){
+            const aSenhaEstaCorreta = await bcrypt.compare(data.usuario_senha, usuarioLogando.usuario_senha)
             if (aSenhaEstaCorreta) {
-                console.log('Senha correta!')
                 const token = jwt.sign({
-                    data: usuario.usuario_id
+                    data: usuarioLogando.usuario_id
                 }, process.env.SECRET, { expiresIn: '1h' })
                 return {
-                    usuario_nome: usuario.usuario_nome,
-                    usuario_email: usuario.usuario_email,
+                    usuario_nome: usuarioLogando.usuario_nome,
+                    usuario_email: usuarioLogando.usuario_email,
                     token
                 }
             } else {
-                console.log('Senha incorreta!')
                 return {
                     status: 422,
                     detail: "Usuário ou senha incorretos.",

--- a/src/database/index.js
+++ b/src/database/index.js
@@ -1,6 +1,9 @@
 require('dotenv').config()
 
 const mysql = require("mysql2/promise");
+const { PrismaClient } = require('@prisma/client');
+
+const prisma = new PrismaClient();
 
 async function executarSQL(query){
     const conexao = await mysql.createConnection({
@@ -12,11 +15,12 @@ async function executarSQL(query){
 
     const [result] = await conexao.query(query);
 
-    conexao.end();
+    await conexao.end();
 
     return result;
 }
 
 module.exports = {
-    executarSQL
+    executarSQL,
+    prisma
 }


### PR DESCRIPTION
Refatora o Controller de Usuarios para utilizar o Prisma ORM.
Implementa listarUsuarios, listarUmUsuario, criarUsuario, apagarUsuario e logar.

@gleidsonteixeira
O usuário do DB refo_fs31 não tinha permissão para criar bancos. Isso fez com que o Prisma não pudesse criar o Shadow Database durante a Migration. Utilizei um banco de dados pessoal pra utilizar no Shadow DB de forma temporária.